### PR TITLE
feat(parser): add Vietnamese prompt for visual figure description

### DIFF
--- a/deepdoc/parser/figure_parser.py
+++ b/deepdoc/parser/figure_parser.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from PIL import Image
 
 from rag.app.picture import vision_llm_chunk as picture_vision_llm_chunk
-from rag.prompts import vision_llm_figure_describe_prompt
+from rag.prompts import vision_llm_figure_describe_prompt, vision_llm_figure_describe_prompt_vietnamese
 
 
 def vision_figure_parser_figure_data_wrapper(figures_data_without_positions):
@@ -84,7 +84,7 @@ class VisionFigureParser:
             description_text = picture_vision_llm_chunk(
                 binary=figure_binary,
                 vision_model=self.vision_model,
-                prompt=vision_llm_figure_describe_prompt(),
+                prompt=vision_llm_figure_describe_prompt_vietnamese(),
                 callback=callback,
             )
             return figure_idx, description_text

--- a/rag/prompts.py
+++ b/rag/prompts.py
@@ -486,3 +486,29 @@ Output format (include only sections relevant to the image content):
 Ensure high accuracy, clarity, and completeness in your analysis, and include only the information present in the image. Avoid unnecessary statements about missing elements.
 """
     return prompt
+
+
+def vision_llm_figure_describe_prompt_vietnamese() -> str:
+    prompt = """
+Bạn là một chuyên gia phân tích dữ liệu trực quan. Hãy phân tích hình ảnh và cung cấp mô tả chi tiết về nội dung của nó. Tập trung vào việc xác định loại biểu diễn dữ liệu trực quan (ví dụ: biểu đồ cột, biểu đồ tròn, biểu đồ đường, bảng, sơ đồ luồng), cấu trúc của hình ảnh, và bất kỳ chú thích hoặc nhãn văn bản nào có trong hình.
+
+Các nhiệm vụ:
+1. Mô tả cấu trúc tổng thể của biểu diễn trực quan. Chỉ rõ đây là biểu đồ, đồ thị, bảng hay sơ đồ.
+2. Xác định và trích xuất các trục, chú giải (legend), tiêu đề hoặc nhãn có trong hình ảnh. Cung cấp chính xác văn bản nếu có thể.
+3. Trích xuất các điểm dữ liệu từ các yếu tố trực quan (ví dụ: độ cao của cột, tọa độ của biểu đồ đường, phần trong biểu đồ tròn, các hàng và cột trong bảng).
+4. Phân tích và giải thích bất kỳ xu hướng, sự so sánh hoặc mô hình nào được thể hiện trong dữ liệu.
+5. Ghi lại bất kỳ chú thích, tiêu đề phụ hoặc ghi chú nào, và giải thích ý nghĩa của chúng đối với hình ảnh.
+6. Chỉ bao gồm những chi tiết được thể hiện rõ ràng trong hình ảnh. Nếu một yếu tố (ví dụ: trục, chú giải hoặc chú thích) không tồn tại hoặc không nhìn thấy được, thì không cần đề cập đến.
+
+Định dạng đầu ra (chỉ bao gồm các phần có liên quan đến nội dung hình ảnh):
+- Loại hình trực quan: [Loại hình]
+- Tiêu đề: [Văn bản tiêu đề, nếu có]
+- Trục / Chú giải / Nhãn: [Chi tiết, nếu có]
+- Dữ liệu: [Dữ liệu được trích xuất]
+- Xu hướng / Nhận định: [Phân tích và diễn giải]
+- Chú thích / Ghi chú: [Văn bản và ý nghĩa, nếu có]
+
+Đảm bảo độ chính xác cao, rõ ràng và đầy đủ trong phần phân tích, và chỉ bao gồm thông tin thực sự có trong hình ảnh. Tránh những tuyên bố không cần thiết về các yếu tố bị thiếu.
+"""
+    return prompt
+


### PR DESCRIPTION
### ✅ Summary

- Added `vision_llm_figure_describe_prompt_vietnamese()` to `rag/prompts.py`
- Updated `VisionFigureParser` to use the Vietnamese prompt instead of the English one for better localization

---

### ❓ What problem does this PR solve?

Currently, the figure description logic only supports English prompts, which may not be suitable for Vietnamese-language documents.  
This PR introduces a Vietnamese prompt tailored for describing figures, tables, and charts in Vietnamese academic and technical documents, improving usability and output relevance for local users.

---

### 🧩 Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)  
- [x] New Feature (non-breaking change which adds functionality)  
- [ ] Documentation Update  
- [ ] Refactoring  
- [ ] Performance Improvement  
- [ ] Other (please describe):

---

### 📎 Additional Context (if any)

This update is part of the effort to support multilingual RAG pipelines. English prompt can still be re-integrated later through configuration if needed.
