### PR TITLE
refactor(refine): dynamic full_question_prompt

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -252,7 +252,7 @@ def chat(dialog, messages, stream=True, **kwargs):
             prompt_config["system"] = prompt_config["system"].replace("{%s}" % p["key"], " ")
 
     if len(questions) > 1 and prompt_config.get("refine_multiturn"):
-        questions = [full_question(dialog.tenant_id, dialog.llm_id, messages)]
+        questions = [full_question(dialog.tenant_id, dialog.llm_id, messages, kwargs.get('full_question_prompt', None))]
     else:
         questions = questions[-1:]
 

--- a/rag/prompts.py
+++ b/rag/prompts.py
@@ -185,7 +185,7 @@ def question_proposal(chat_mdl, content, topn=3):
     return kwd
 
 
-def full_question(tenant_id, llm_id, messages, language=None):
+def full_question(tenant_id, llm_id, messages, language=None, full_question_prompt=None):
     from api.db import LLMType
     from api.db.services.llm_service import LLMBundle
 
@@ -203,7 +203,7 @@ def full_question(tenant_id, llm_id, messages, language=None):
     yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
     tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 
-    template = PROMPT_JINJA_ENV.from_string(FULL_QUESTION_PROMPT_TEMPLATE)
+    template = PROMPT_JINJA_ENV.from_string(full_question_prompt or FULL_QUESTION_PROMPT_TEMPLATE)
     print("Full question prompt template:", template)
     rendered_prompt = template.render(
         today=today,


### PR DESCRIPTION
### ✅ What problem does this PR solve?

Previously, prompts were hardcoded in `.md` files, which limited flexibility and made it difficult to reuse or adapt prompts dynamically based on context. This PR enables external prompt injection, allowing prompts to be passed in from outside sources (e.g., API payloads, environment variables, or config files). This makes the system more modular, configurable, and easier to integrate with different workflows or use cases.

This change is especially useful for supporting multiple dynamic prompt scenarios without having to duplicate or modify internal code or markdown files.

---

### ✅ Type of change

* [ ] Bug Fix (non-breaking change which fixes an issue)
* [ ] New Feature (non-breaking change which adds functionality)
* [ ] Documentation Update
* [x] Refactoring
* [ ] Performance Improvement
* [ ] Other (please describe):
